### PR TITLE
Added a check for spurious counterexamples for parsing nuXmv output

### DIFF
--- a/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/processors/nuxmv/NuxmvOutputInterpreter.xtend
+++ b/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/processors/nuxmv/NuxmvOutputInterpreter.xtend
@@ -16,7 +16,6 @@ import de.cau.cs.kieler.verification.VerificationPropertyCounterexample
 import de.cau.cs.kieler.verification.codegen.SmvCodeGeneratorExtensions
 import de.cau.cs.kieler.verification.processors.LineBasedParser
 import java.util.List
-import java.util.TreeMap
 import java.util.regex.Pattern
 import org.eclipse.xtend.lib.annotations.Accessors
 

--- a/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/processors/nuxmv/NuxmvOutputInterpreter.xtend
+++ b/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/processors/nuxmv/NuxmvOutputInterpreter.xtend
@@ -16,6 +16,7 @@ import de.cau.cs.kieler.verification.VerificationPropertyCounterexample
 import de.cau.cs.kieler.verification.codegen.SmvCodeGeneratorExtensions
 import de.cau.cs.kieler.verification.processors.LineBasedParser
 import java.util.List
+import java.util.TreeMap
 import java.util.regex.Pattern
 import org.eclipse.xtend.lib.annotations.Accessors
 
@@ -36,8 +37,12 @@ class NuxmvOutputInterpreter extends LineBasedParser {
     private static val LOOP_START_PATTERN = Pattern.compile('''.*-- Loop starts here''')
     private static val ISSUE_IN_FILE_PATTERN = Pattern.compile('''(.*)file(.*): line (\d+):(.*)''')
     private static val TERMINATED_BY_SIGNAL_PATTERN = Pattern.compile('''.*nuXmv terminated by a signal''')
+    //This can help find the end of a spurious trace.
+    private static val SPOURIOUS_COUNTEREXAMPLE_PATTERN = Pattern.compile('''.*-- Counterexample is SPURIOUS at bound.*''')
     
     private var boolean parseCounterexamples = true
+    
+    
     
     private enum ParseTarget {
         SPEC_RESULT,
@@ -51,6 +56,7 @@ class NuxmvOutputInterpreter extends LineBasedParser {
         this.parseCounterexamples = parseCounterexamples
         parse(processOutput)
     }
+    
     
     override parseLine(String line) {
         val trimmedLine = line.trim
@@ -80,6 +86,15 @@ class NuxmvOutputInterpreter extends LineBasedParser {
                 throw new Exception('''Inconsistent specification result state (expected true or false, but got line: «line»)''')
             }
         } else if (parseCounterexamples && parseTarget == ParseTarget.COUNTEREXAMPLE) {
+            // Find if Counterexample is Spurious
+            val spuriousMatcher = SPOURIOUS_COUNTEREXAMPLE_PATTERN.matcher(trimmedLine)
+            if(spuriousMatcher.matches && !counterexamples.empty) {
+                // Counterexample is spurious (not a valid counterexample) -> reset the parseTarget
+                //    and delete the current Counterexample (first from the list, then the obj itself)
+                parseTarget = ParseTarget.SPEC_RESULT
+                counterexamples.remove(counterexamples.length - 1)
+                currentCounterexample = null
+            }
             // Find the start of the next state
             val stateMatcher = STATE_PATTERN.matcher(trimmedLine)
             if(stateMatcher.matches) {


### PR DESCRIPTION
Added a check for spurious counterexamples for parsing nuXmv output in the verification plugin.

Closes #1 

Old: In the class `NuxmvOutputInterpreter` in package `de.cau.cs.kieler.verification.processors.nuxmv`, an overridden method parseLine handles parsing the nuXmv output. When the start of a counterexample is detected, it searches for information about this counterexample in subsequent lines.
Addition: I added a check for a sudden (spurious) end of a counterexample by checking for "-- Counterexample is SPURIOUS at bound...". If this line is detected whilst parsing a counterexample, the current counterexample is thrown out and we go back to searching for result specifications (whether a property is true or false).

I tested this against multiple SCTX models with various properties. Overall behavior only changes for verification attempts where spurious counterexamples occur. A spurious counterexample does not lead to the verification to result in "FAILED" anymore, assuming that the property is actually true (proven later in the log). Behavior stayed the same for all other configurations; i.e. if no spurious counterexample occurs, we get the correct result like before.

If anyone else wants to test this, provoking a spurious counterexample is actually not that easy. I cannot share the model that consistently produces them for me on here publicly. If you don't have a model that does but want to test it, send me a message on github or request it in a comment here.
An example trace with spurious counterexamples can be found in Issue #1 .
