### PR TITLE
build: Added GH Actions build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,196 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch: # manual triggering, for debugging purposes
+
+jobs:
+  mavenBuilds:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # Setup
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('.github/workflows/*.*', '**/pom.xml', '**/META-INF/MANIFEST.MF', 'build/de.cau.cs.kieler.semantics.targetplatform/de.cau.cs.kieler.semantics.targetplatform.target') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      # Maven build update site
+      - name: Build update site
+        run: MAVEN_OPTS="-Xmx2048M" mvn --update-snapshots clean verify -P semantics --file build/pom.xml
+      
+      # Maven build products
+      - name: Build products
+        run: MAVEN_OPTS="-Xmx2048M" mvn --update-snapshots clean package -P semantics.product --file build/pom.xml
+
+      ##################################### ALL THE ARTIFACTS #####################################
+
+      # Archive Repository
+      - name: Archive Semantics Repository Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Semantics Repository Artifact
+          path: build/de.cau.cs.kieler.semantics.repository/target/repository/
+          if-no-files-found: error
+
+      # Archive Eclipse RCA
+      - name: Archive KIELER Semantics RCA Windows
+        uses: actions/upload-artifact@v2
+        with:
+          name: KIELER RCA Windows
+          path: build/de.cau.cs.kieler.semantics.product.repository/target/products/sccharts_rca_nightly_*-linux.gtk.x86_64.tar.gz
+          if-no-files-found: error
+
+      - name: Archive KIELER Semantics RCA Linux
+        uses: actions/upload-artifact@v2
+        with:
+          name: KIELER RCA Linux
+          path: build/de.cau.cs.kieler.semantics.product.repository/target/products/sccharts_rca_nightly_*-win32.win32.x86_64.zip
+          if-no-files-found: error
+
+      - name: Archive KIELER Semantics RCA MacOS
+        uses: actions/upload-artifact@v2
+        with:
+          name: KIELER RCA MacOS
+          path: build/de.cau.cs.kieler.semantics.product.repository/target/products/sccharts_rca_nightly_*-macosx.cocoa.x86_64.tar.gz
+          if-no-files-found: error
+
+      # Kieler Compiler CLI
+      - name: Archive KIELER Compiler CLI Jar
+        uses: actions/upload-artifact@v2
+        with:
+          name: KIELER Compiler CLI Jar
+          path: build/de.cau.cs.kieler.kicool.cli/target/exe/kico.jar
+          if-no-files-found: error
+
+      - name: Archive KIELER Compiler CLI Windows
+        uses: actions/upload-artifact@v2
+        with:
+          name: KIELER Compiler CLI Windows
+          path: build/de.cau.cs.kieler.kicool.cli/target/exe/kico-win.bat
+          if-no-files-found: error
+
+      - name: Archive KIELER Compiler CLI Linux
+        uses: actions/upload-artifact@v2
+        with:
+          name: KIELER Compiler CLI Linux
+          path: build/de.cau.cs.kieler.kicool.cli/target/exe/kico-linux
+          if-no-files-found: error
+
+      - name: Archive KIELER Compiler CLI MacOS
+        uses: actions/upload-artifact@v2
+        with:
+          name: KIELER Compiler CLI MacOS
+          path: build/de.cau.cs.kieler.kicool.cli/target/exe/kico-osx
+          if-no-files-found: error
+
+      # Kieler Compiler Diagrams CLI
+      - name: Archive KIELER Compiler Diagrams CLI Windows Jar
+        uses: actions/upload-artifact@v2
+        with:
+          name: KIELER Compiler Diagrams CLI Windows Jar
+          path: build/de.cau.cs.kieler.kicool.klighd.cli/target/exe/kicodia.win.jar
+          if-no-files-found: error
+
+      - name: Archive KIELER Compiler Diagrams CLI Linux Jar
+        uses: actions/upload-artifact@v2
+        with:
+          name: KIELER Compiler Diagrams CLI Linux Jar
+          path: build/de.cau.cs.kieler.kicool.klighd.cli/target/exe/kicodia.linux.jar
+          if-no-files-found: error
+
+      - name: Archive KIELER Compiler Diagrams CLI MacOS Jar
+        uses: actions/upload-artifact@v2
+        with:
+          name: KIELER Compiler Diagrams CLI MacOS Jar
+          path: build/de.cau.cs.kieler.kicool.klighd.cli/target/exe/kicodia.osx.jar
+          if-no-files-found: error
+
+      - name: Archive KIELER Compiler Diagrams CLI Windows
+        uses: actions/upload-artifact@v2
+        with:
+          name: KIELER Compiler Diagrams CLI Windows
+          path: build/de.cau.cs.kieler.kicool.klighd.cli/target/exe/kicodia-win.bat
+          if-no-files-found: error
+
+      - name: Archive KIELER Compiler Diagrams CLI Linux
+        uses: actions/upload-artifact@v2
+        with:
+          name: KIELER Compiler Diagrams CLI Linux
+          path: build/de.cau.cs.kieler.kicool.klighd.cli/target/exe/kicodia-linux
+          if-no-files-found: error
+
+      - name: Archive KIELER Compiler Diagrams CLI MacOS
+        uses: actions/upload-artifact@v2
+        with:
+          name: KIELER Compiler Diagrams CLI MacOS
+          path: build/de.cau.cs.kieler.kicool.klighd.cli/target/exe/kicodia-osx
+          if-no-files-found: error
+
+      # SCCharts Compiler CLI
+      - name: Archive SCCharts Compiler CLI Jar
+        uses: actions/upload-artifact@v2
+        with:
+          name: SCCharts Compiler CLI Jar
+          path: build/de.cau.cs.kieler.sccharts.cli/target/exe/scc.jar
+          if-no-files-found: error
+
+      - name: Archive SCCharts Compiler CLI Windows
+        uses: actions/upload-artifact@v2
+        with:
+          name: SCCharts Compiler CLI Windows
+          path: build/de.cau.cs.kieler.sccharts.cli/target/exe/scc-win.bat
+          if-no-files-found: error
+
+      - name: Archive SCCharts Compiler CLI Linux
+        uses: actions/upload-artifact@v2
+        with:
+          name: SCCharts Compiler CLI Linux
+          path: build/de.cau.cs.kieler.sccharts.cli/target/exe/scc-linux
+          if-no-files-found: error
+
+      - name: Archive SCCharts Compiler CLI MacOS
+        uses: actions/upload-artifact@v2
+        with:
+          name: SCCharts Compiler CLI MacOS
+          path: build/de.cau.cs.kieler.sccharts.cli/target/exe/scc-osx
+          if-no-files-found: error
+
+      # Kieler Language Server
+      - name: Archive KIELER Language Server Windows
+        uses: actions/upload-artifact@v2
+        with:
+          name: KIELER Language Server Windows
+          path: build/de.cau.cs.kieler.language.server.cli/target/exe/kieler-language-server.win.jar
+          if-no-files-found: error
+
+      - name: Archive KIELER Language Server Linux
+        uses: actions/upload-artifact@v2
+        with:
+          name: KIELER Language Server Linux
+          path: build/de.cau.cs.kieler.language.server.cli/target/exe/kieler-language-server.linux.jar
+          if-no-files-found: error
+
+      - name: Archive KIELER Language Server MacOS
+        uses: actions/upload-artifact@v2
+        with:
+          name: KIELER Language Server MacOS
+          path: build/de.cau.cs.kieler.language.server.cli/target/exe/kieler-language-server.osx.jar
+          if-no-files-found: error


### PR DESCRIPTION
Migration of nightly Semantics build from Bamboo.
- builds the repo and products
- triggers on pushes to master, PRs to master by trusted users, or manually by collaborators.
- adds the repository (automatically zipped) and all CLI and LS jars and executables to the build
- all artifacts and logs will be unavailable after GitHub's default retention period of 90 days.
- automatic hosting of the nightly repository externally will soon be implemented (not here on GitHub though). Would also work for all other artifacts, if wanted
- testing against our models repository is not in this CI yet, mainly because of difficulties with multiple repositories in a single build and private repsitories in general.