### PR TITLE
Swapped the path of Semantics RCA Linux and Windows in the github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,14 +55,14 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: KIELER RCA Windows
-          path: build/de.cau.cs.kieler.semantics.product.repository/target/products/sccharts_rca_nightly_*-linux.gtk.x86_64.tar.gz
+          path: build/de.cau.cs.kieler.semantics.product.repository/target/products/sccharts_rca_nightly_*-win32.win32.x86_64.zip
           if-no-files-found: error
 
       - name: Archive KIELER Semantics RCA Linux
         uses: actions/upload-artifact@v2
         with:
           name: KIELER RCA Linux
-          path: build/de.cau.cs.kieler.semantics.product.repository/target/products/sccharts_rca_nightly_*-win32.win32.x86_64.zip
+          path: build/de.cau.cs.kieler.semantics.product.repository/target/products/sccharts_rca_nightly_*-linux.gtk.x86_64.tar.gz
           if-no-files-found: error
 
       - name: Archive KIELER Semantics RCA MacOS


### PR DESCRIPTION
This closes #9 
The path of the Semantics RCA build was swapped between Windows and Linux. I've swapped the respective paths in the config file to fix that. No other paths/names appear to be mixed up in the config.