### PR TITLE
Change consumption of nuXmv child process output to prevent deadlock in verification

### DIFF
--- a/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/processors/ProcessExtensions.xtend
+++ b/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/processors/ProcessExtensions.xtend
@@ -66,7 +66,7 @@ class ProcessExtensions {
      * When finished or canceled, returns with the output that was read so far. 
      */
     public static def String readUntilFinishedOrCanceled(Process proc, Function<Void, Boolean> processCanceled){
-    	var boolean finished = !proc.isAlive
+        var boolean finished = !proc.isAlive
         var boolean canceled = processCanceled.apply(null)
         val stringBuffer = new StringBuffer
         val inputStream = proc.inputStream
@@ -75,12 +75,12 @@ class ProcessExtensions {
             canceled = processCanceled.apply(null)
             finished = proc.waitFor(5, TimeUnit.MILLISECONDS)
             //Read available data (the stream can still contain valid data if the process is finished) 
-        	while(inputStream.available > 0) {
-	            val int b = inputStream.read
-	            if(b != -1){
-	            	stringBuffer.append( b as char )
-	            }
-	        }
+            while(inputStream.available > 0) {
+                val int b = inputStream.read
+                if(b != -1){
+                    stringBuffer.append( b as char )
+                }
+            }
         }
         if(canceled) {
             proc.kill

--- a/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/processors/nuxmv/RunSmvProcessor.xtend
+++ b/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/processors/nuxmv/RunSmvProcessor.xtend
@@ -151,7 +151,8 @@ abstract class RunSmvProcessor extends RunModelCheckerProcessorBase {
             process.outputStream.flush
             // Update the property so the user sees, which command is executed now
             updateTaskDescriptionAndNotify(property, '''Running Model Checker... «command»...''')
-            // Add the sent command to the outputBuffer, so one can understand what happened when viewing the log
+            // Add the sent command to the outputBuffer, 
+            // so one can understand what happened when viewing the log
             // TODO: The position in the ouput is sometimes not correct (race condition) 
             outputBuffer.append(commandWithNewline)
             // Wait for new output from the process
@@ -159,10 +160,10 @@ abstract class RunSmvProcessor extends RunModelCheckerProcessorBase {
             throwIfCanceled
             outputBuffer.append(process.readInputStream)
         }
-        // Wait until the process is done with all commands -> read from process and also continuously check if user wants it canceled.
+        // Read until process is finished or a cancel request has been made.
         outputBuffer.append(process.readUntilFinishedOrCanceled([ return isCanceled() ]))
-        // Get combined process output
         val processOutput = outputBuffer.toString
+        
         throwIfCanceled
         return processBuilder.command.toString.replace("\n", "\\n") + "\n" + processOutput
     }

--- a/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/processors/nuxmv/RunSmvProcessor.xtend
+++ b/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/processors/nuxmv/RunSmvProcessor.xtend
@@ -159,9 +159,8 @@ abstract class RunSmvProcessor extends RunModelCheckerProcessorBase {
             throwIfCanceled
             outputBuffer.append(process.readInputStream)
         }
-        // Wait until the process is done with all commands
-        process.waitForTermination([ return isCanceled() ])
-        outputBuffer.append(process.readInputStream)
+        // Wait until the process is done with all commands -> read from process and also continuously check if user wants it canceled.
+        outputBuffer.append(process.readUntilFinishedOrCanceled([ return isCanceled() ]))
         // Get combined process output
         val processOutput = outputBuffer.toString
         throwIfCanceled


### PR DESCRIPTION
Fixes #8 

The details are described in the linked issue. In short, when running nuXmv as a separate process for verification, Kieler waits for nuXmv to finish or be canceled (at least if nuXmv doesn't finish immediately/very fast). It does not consume the process output during that time - it is consumed after the process finishes, assuming it isn't canceled. If the output buffer of the nuxmv process runs full, nuXmv effectively stops and never finishes (process still counts as alive). As a result, Kieler waits indefinitely for nuXmv to finish. 
This problem can occur on any operating system. However, the buffer size is the lowest (that I know of) in Windows, so this issue was first detected there.

The fix is to both check for end/cancellation and consume the output at the same time. I created a method based on the two existing methods for achieving these goals, re-using the same technique (i.e. same classes, methods etc.). I tested my fix on Windows and Linux (Ubuntu 20.04) to ensure that it a) fixes the problem I saw on Windows and b) does not break any functionality on Linux. In addition to ensuring that the deadlock is eliminated, I checked that cancellation still works (it does).

To try and trigger the issue that led to this pull request, follow the steps described in the third comment in issue #8 

(Meta comment: Is there a way to prevent a github actions build on draft pull requests? I canceled it, as it won't have my update integrated anyway due to #11 )