### PR TITLE
Fix infinite self-loop due to exit transformation

### DIFF
--- a/plugins/de.cau.cs.kieler.sccharts/src/de/cau/cs/kieler/sccharts/processors/Exit.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts/src/de/cau/cs/kieler/sccharts/processors/Exit.xtend
@@ -138,9 +138,9 @@ class Exit extends SCChartsProcessor implements Traceable {
             lastState = region.createFinalState(GENERATED_PREFIX + "Done")
         } else if (state.regions.filter(ControlflowRegion).size == 1 && !state.regions.filter(ControlflowRegion).head.allFinalStates.nullOrEmpty) {
             val region = state.regions.filter(ControlflowRegion).head
-            lastState = region.createFinalState(GENERATED_PREFIX + "Done")
-
             firstState = region.getOrCreateSimpleFinalState(GENERATED_PREFIX + "PriorFinal") //every region MUST have an initial state
+            
+            lastState = region.createFinalState(GENERATED_PREFIX + "Done")
             //firstState = region.finalStates.get(0) //every region MUST have a final state
             firstState.setNotFinal
             for (otherFinalState : region.allFinalStates) {


### PR DESCRIPTION
When checking for applicable final states, the processor no longer defaults to the "_Done" state if a different final state already exists.
Closes #14