### PR TITLE
Changed behavior of verification properties in regular compilation

### DIFF
--- a/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/sccharts/processors/verification/SCChartsVerificationPropertyAnalyzer.xtend
+++ b/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/sccharts/processors/verification/SCChartsVerificationPropertyAnalyzer.xtend
@@ -55,9 +55,10 @@ class SCChartsVerificationPropertyAnalyzer extends InplaceProcessor<SCCharts>  {
     }
     
     override process() {
-        val verificationContext = compilationContext.asVerificationContext
+        var verificationContext = compilationContext.verificationContext
         if(verificationContext === null) {
-            return
+            // This will result in synthesizing assumption and properties even in normal compilation
+            verificationContext = compilationContext.createVerificationContext(false)
         }
         
         // Only set the properties in the environment if they are not set yet.

--- a/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/VerificationContext.xtend
+++ b/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/VerificationContext.xtend
@@ -18,11 +18,15 @@ import org.eclipse.core.resources.IFile
 import org.eclipse.xtend.lib.annotations.Accessors
 import de.cau.cs.kieler.kexpressions.ValuedObject
 import de.cau.cs.kieler.verification.RangeAssumption
+import de.cau.cs.kieler.kicool.classes.IKiCoolCloneable
 
 /** 
  * @author aas
  */
-class VerificationContext extends CompilationContext {
+class VerificationContext implements IKiCoolCloneable {
+    
+    // Switch between generic verification code generation and actual verification run
+    @Accessors private boolean verify = false
     
     // General options
     @Accessors private List<VerificationProperty> verificationProperties = newArrayList
@@ -73,4 +77,13 @@ class VerificationContext extends CompilationContext {
     def void addRangeAssumtion(ValuedObject vo, int start, int end) {
         this.verificationAssumptions.add(new RangeAssumption(vo, start, end))
     }
+    
+    override cloneObject() {
+        this
+    }
+    
+    override isMutable() {
+        false
+    }
+    
 }

--- a/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/extensions/VerificationContextExtensions.xtend
+++ b/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/extensions/VerificationContextExtensions.xtend
@@ -12,28 +12,46 @@
  */
 package de.cau.cs.kieler.verification.extensions
 
+import de.cau.cs.kieler.core.properties.IProperty
+import de.cau.cs.kieler.core.properties.Property
 import de.cau.cs.kieler.kicool.compilation.CompilationContext
 import de.cau.cs.kieler.kicool.compilation.codegen.CodeGeneratorModule
 import de.cau.cs.kieler.verification.VerificationContext
+import de.cau.cs.kieler.kicool.environments.Environment
 
 /** 
  * @author aas
+ * @author als
  */
 class VerificationContextExtensions {
     
-    public static def VerificationContext asVerificationContext(CompilationContext context) {
-        if(context instanceof VerificationContext) {
-            return context
-        } else {
-            return null
+    public static val IProperty<VerificationContext> VERIFICATION_CONTEXT = 
+        new Property<VerificationContext>("de.cau.cs.kieler.verification.context")
+    
+    public static def VerificationContext createVerificationContext(CompilationContext context, boolean runModelChecker) {
+        if (!context.hasVerificationContext()) {
+            context.startEnvironment.setProperty(VERIFICATION_CONTEXT, new VerificationContext())
         }
+        return context.verificationContext => [it.verify = runModelChecker]
+    }
+    
+    public static def VerificationContext getVerificationContext(Environment env) {
+        return env.getProperty(VERIFICATION_CONTEXT)
+    }
+    
+    public static def VerificationContext getVerificationContext(CompilationContext context) {
+        return context.startEnvironment.verificationContext
     }
     
     public static def VerificationContext getVerificationContext(CodeGeneratorModule<?, ?> codeGenModule) {
-        return codeGenModule.processorInstance.compilationContext.asVerificationContext
+        return codeGenModule.processorInstance.compilationContext.verificationContext
     }
     
-    public static def boolean isVerificationContext(CompilationContext context) {
-        return (context instanceof VerificationContext)
+    public static def boolean hasVerificationContext(CompilationContext context) {
+        return context.verificationContext !== null
+    }
+    
+    public static def boolean hasVerificationContext(Environment env) {
+        return env.verificationContext !== null
     }
 }

--- a/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/processors/RunModelCheckerProcessorBase.xtend
+++ b/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/processors/RunModelCheckerProcessorBase.xtend
@@ -78,7 +78,7 @@ abstract class RunModelCheckerProcessorBase extends Processor<CodeContainer, Obj
     }
     
     protected def VerificationContext getVerificationContext() {
-        return compilationContext.asVerificationContext
+        return compilationContext.verificationContext
     }
     
     protected def IPath getOutputFolder() {

--- a/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/processors/nuxmv/RunSmvProcessor.xtend
+++ b/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/processors/nuxmv/RunSmvProcessor.xtend
@@ -50,7 +50,7 @@ abstract class RunSmvProcessor extends RunModelCheckerProcessorBase {
     }
     
     override process() {
-        if(!compilationContext.isVerificationContext) {
+        if(!compilationContext.hasVerificationContext || !compilationContext.verificationContext.verify) {
             return
         }
         

--- a/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/processors/spin/RunSpinProcessor.xtend
+++ b/plugins/de.cau.cs.kieler.verification/src/de/cau/cs/kieler/verification/processors/spin/RunSpinProcessor.xtend
@@ -45,7 +45,7 @@ class RunSpinProcessor extends RunModelCheckerProcessorBase {
     }
     
     override process() {
-        if(!compilationContext.isVerificationContext) {
+        if(!compilationContext.hasVerificationContext || !compilationContext.verificationContext.verify) {
             return
         }
         

--- a/test/de.cau.cs.kieler.verification.test/src/de/cau/cs/kieler/test/verification/AbstractVerificationTest.xtend
+++ b/test/de.cau.cs.kieler.verification.test/src/de/cau/cs/kieler/test/verification/AbstractVerificationTest.xtend
@@ -13,6 +13,7 @@
 package de.cau.cs.kieler.test.verification
 
 import com.google.inject.Injector
+import de.cau.cs.kieler.kicool.compilation.CompilationContext
 import de.cau.cs.kieler.kicool.compilation.CompilationSystem
 import de.cau.cs.kieler.kicool.compilation.Compile
 import de.cau.cs.kieler.kicool.compilation.observer.CompilationFinished
@@ -22,7 +23,6 @@ import de.cau.cs.kieler.simulation.testing.TestModelData
 import de.cau.cs.kieler.test.common.repository.AbstractXTextModelRepositoryTest
 import de.cau.cs.kieler.test.common.repository.ModelsRepositoryTestRunner
 import de.cau.cs.kieler.verification.VerificationAssumption
-import de.cau.cs.kieler.verification.VerificationContext
 import de.cau.cs.kieler.verification.VerificationProperty
 import de.cau.cs.kieler.verification.VerificationPropertyChanged
 import de.cau.cs.kieler.verification.VerificationPropertyStatus
@@ -36,6 +36,7 @@ import org.junit.runner.RunWith
 
 import static org.junit.Assert.*
 
+import static extension de.cau.cs.kieler.verification.extensions.VerificationContextExtensions.*
 import static extension de.cau.cs.kieler.verification.processors.ProcessExtensions.*
 
 /**
@@ -47,7 +48,7 @@ abstract class AbstractVerificationTest<T extends EObject> extends AbstractXText
 
     public static val MUST_FAIL_PATTERN_KEY = "verification-must-fail-pattern"
     
-    protected var VerificationContext currentVerificationContext
+    protected var CompilationContext currentContext
     
     protected var T verificationModel
     protected var TestModelData verificationModelData
@@ -90,31 +91,31 @@ abstract class AbstractVerificationTest<T extends EObject> extends AbstractXText
         // Get verification properties
         val processorId = getPropertyAnalyzerProcessorId()
         val propertyAnalyzerContext = runPropertyAnalyzer(processorId)
-        verificationProperties = propertyAnalyzerContext.verificationProperties
-        verificationAssumptions = propertyAnalyzerContext.verificationAssumptions
+        verificationProperties = propertyAnalyzerContext.verificationContext.verificationProperties
+        verificationAssumptions = propertyAnalyzerContext.verificationContext.verificationAssumptions
     }
     
     @After
     public def void stopCurrentVerification() {
-        if(currentVerificationContext === null) {
+        if(currentContext === null) {
             return
         }
         // Cancel verification
-        currentVerificationContext.startEnvironment.setProperty(Environment.CANCEL_COMPILATION, true)
+        currentContext.startEnvironment.setProperty(Environment.CANCEL_COMPILATION, true)
         
         // Kill process        
-        val process = currentVerificationContext.verificationProcess
+        val process = currentContext.verificationContext.verificationProcess
         if(process !== null && process.isAlive) {
             System.err.println("Killing verification process after test run")
             process.kill
         }
         
-        currentVerificationContext = null
+        currentContext = null
     }
     
     protected def void startVerification(List<VerificationProperty> properties, List<VerificationAssumption> assumptions) {
         stopCurrentVerification()
-        currentVerificationContext = createVerificationContext(properties, assumptions)
+        currentContext = createVerificationContext(properties, assumptions)
         
         // Update task description of the properties 
         for(property : verificationProperties) {
@@ -122,31 +123,33 @@ abstract class AbstractVerificationTest<T extends EObject> extends AbstractXText
             property.status = VerificationPropertyStatus.RUNNING
         }
         
-        currentVerificationContext.compile
+        currentContext.compile
     }
     
-    protected def VerificationContext createVerificationContext(List<VerificationProperty> properties, List<VerificationAssumption> assumptions) {
+    protected def CompilationContext createVerificationContext(List<VerificationProperty> properties, List<VerificationAssumption> assumptions) {
         // Create new context for verification and compile
         val systemId = getVerificationSystemId()
-        val context = Compile.createCompilationContext(systemId, verificationModel, VerificationContext)
+        val context = Compile.createCompilationContext(systemId, verificationModel)
+        val verificationContext = context.createVerificationContext(true)
         context.startEnvironment.setProperty(Environment.INPLACE, true)
         context.startEnvironment.setProperty(ProjectInfrastructure.TEMPORARY_PROJECT_NAME, this.class.simpleName)
         
-        context.verificationProperties = properties
-        context.verificationAssumptions = assumptions
+        verificationContext.verificationProperties = properties
+        verificationContext.verificationAssumptions = assumptions
         
         val modelFile = getVerificationModelFileHandle()
-        context.verificationModelFile = modelFile
+        verificationContext.verificationModelFile = modelFile
         
         context.configureContext()
         
         return context
     }
     
-    protected def VerificationContext runPropertyAnalyzer(String processorId) {
+    protected def CompilationContext runPropertyAnalyzer(String processorId) {
         val compilationSystem = CompilationSystem.createCompilationSystem(processorId, #[processorId])
-        val context = Compile.createCompilationContext(compilationSystem, verificationModel, VerificationContext)
-        context.compile
+        val context = Compile.createCompilationContext(compilationSystem, verificationModel)
+        context.createVerificationContext(false)
+        context.compile()
         if(context.hasErrors) {
             val exception = context.allErrors.get(0).exception
             throw exception
@@ -154,7 +157,7 @@ abstract class AbstractVerificationTest<T extends EObject> extends AbstractXText
         return context
     }
     
-    protected def void configureContext(VerificationContext verificationContext) {
+    protected def void configureContext(CompilationContext verificationContext) {
         // Add observer for changed properties
         verificationContext.addObserver[ Observable o, Object arg |
             if(arg instanceof VerificationPropertyChanged) {

--- a/test/de.cau.cs.kieler.verification.test/src/de/cau/cs/kieler/test/verification/sccharts/SCChartsVerificationBenchmark.xtend
+++ b/test/de.cau.cs.kieler.verification.test/src/de/cau/cs/kieler/test/verification/sccharts/SCChartsVerificationBenchmark.xtend
@@ -44,6 +44,9 @@ import org.junit.rules.TestName
 import org.junit.rules.TestRule
 import org.junit.rules.Timeout
 import org.junit.runner.RunWith
+import de.cau.cs.kieler.kicool.compilation.CompilationContext
+
+import static extension de.cau.cs.kieler.verification.extensions.VerificationContextExtensions.*
 
 /**
  * @author aas
@@ -466,8 +469,10 @@ class SCChartsVerificationBenchmark extends AbstractSCChartsVerificationTest {
         return file
     }
     
-    override configureContext(VerificationContext verificationContext) {
-        super.configureContext(verificationContext)
+    override configureContext(CompilationContext context) {
+        super.configureContext(context)
+        
+        val verificationContext = context.verificationContext
         
         // Add options
         verificationContext.createCounterexamplesWithOutputs = createCounterexamplesWithOutputs
@@ -646,7 +651,7 @@ class SCChartsVerificationBenchmark extends AbstractSCChartsVerificationTest {
     
     private def void fetchStatisticsOfCodeGeneration() {
         var overallTimeNanons = 0l
-        for(processor : currentVerificationContext.processorInstances) {
+        for(processor : currentContext.processorInstances) {
             if(!(processor instanceof RunModelCheckerProcessorBase)) {
                 val env = processor.environment
                 overallTimeNanons += env.getProperty(Environment.TRANSFORMATION_TIME)                

--- a/test/de.cau.cs.kieler.verification.test/src/de/cau/cs/kieler/test/verification/sccharts/SCChartsVerificationSmvTest.xtend
+++ b/test/de.cau.cs.kieler.verification.test/src/de/cau/cs/kieler/test/verification/sccharts/SCChartsVerificationSmvTest.xtend
@@ -12,17 +12,19 @@
  */
 package de.cau.cs.kieler.test.verification.sccharts
 
+import de.cau.cs.kieler.kicool.compilation.CompilationContext
 import de.cau.cs.kieler.sccharts.SCCharts
 import de.cau.cs.kieler.sccharts.text.SCTXStandaloneSetup
 import de.cau.cs.kieler.simulation.testing.TestModelData
 import de.cau.cs.kieler.test.common.repository.ModelsRepositoryTestRunner
-import de.cau.cs.kieler.verification.VerificationContext
 import java.util.List
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.rules.Timeout
 import org.junit.runner.RunWith
+
+import static extension de.cau.cs.kieler.verification.extensions.VerificationContextExtensions.*
 
 /**
  * @author aas
@@ -66,8 +68,10 @@ class SCChartsVerificationSmvTest extends AbstractSCChartsVerificationTest {
         println()
     }
     
-    override configureContext(VerificationContext verificationContext) {
-        super.configureContext(verificationContext)
+    override configureContext(CompilationContext context) {
+        super.configureContext(context)
+        
+        val verificationContext = context.verificationContext
         
         // Add options
         verificationContext.createCounterexamplesWithOutputs = createCounterexampleWithOutputs

--- a/test/de.cau.cs.kieler.verification.test/src/de/cau/cs/kieler/test/verification/sccharts/SCChartsVerificationSpinTest.xtend
+++ b/test/de.cau.cs.kieler.verification.test/src/de/cau/cs/kieler/test/verification/sccharts/SCChartsVerificationSpinTest.xtend
@@ -12,11 +12,11 @@
  */
 package de.cau.cs.kieler.test.verification.sccharts
 
+import de.cau.cs.kieler.kicool.compilation.CompilationContext
 import de.cau.cs.kieler.sccharts.SCCharts
 import de.cau.cs.kieler.sccharts.text.SCTXStandaloneSetup
 import de.cau.cs.kieler.simulation.testing.TestModelData
 import de.cau.cs.kieler.test.common.repository.ModelsRepositoryTestRunner
-import de.cau.cs.kieler.verification.VerificationContext
 import de.cau.cs.kieler.verification.VerificationPropertyType
 import java.util.List
 import org.junit.Rule
@@ -24,6 +24,8 @@ import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.rules.Timeout
 import org.junit.runner.RunWith
+
+import static extension de.cau.cs.kieler.verification.extensions.VerificationContextExtensions.*
 
 /**
  * @author aas
@@ -74,8 +76,10 @@ class SCChartsVerificationSpinTest extends AbstractSCChartsVerificationTest {
         }
     }
     
-    override configureContext(VerificationContext verificationContext) {
-        super.configureContext(verificationContext)
+    override configureContext(CompilationContext context) {
+        super.configureContext(context)
+        
+        val verificationContext = context.verificationContext
         
         // Add options
         verificationContext.createCounterexamplesWithOutputs = createCounterexampleWithOutputs


### PR DESCRIPTION
Verification properties and assumptions will now be synthesized in to generated code in the regular compilation runs (started via Kieler Compiler view) not only during verification (via Model Checking view).

Also changed the role of the VerificationContext from a standalone CompilationContext into an environment property inside a CompilationContext.