### PR TITLE
Adds blacklist for copied annotations in SCG sequentializer

### DIFF
--- a/plugins/de.cau.cs.kieler.scg/src/de/cau/cs/kieler/scg/processors/SimpleGuardSequentializer.xtend
+++ b/plugins/de.cau.cs.kieler.scg/src/de/cau/cs/kieler/scg/processors/SimpleGuardSequentializer.xtend
@@ -64,6 +64,10 @@ class SimpleGuardSequentializer extends Processor<SCGraphs, SCGraphs> implements
     @Inject extension PragmaExtensions
 
     static val String ANNOTATION_HOSTCODE = "hostcode"
+    static val ANNOTATION_COPY_BLACKLIST = #[
+        SCGAnnotations.ANNOTATION_GUARDCREATOR,
+        SCGAnnotations.ANNOTATION_GUARDED        
+    ]
     
     val globalVOMap = <ValuedObject, ValuedObject>newHashMap
      
@@ -108,6 +112,7 @@ class SimpleGuardSequentializer extends Processor<SCGraphs, SCGraphs> implements
          */
          newSCG => [
             scg.copyAnnotations(it, SCGAnnotations.TRANSFORMATION_INDICATORS)
+            annotations.removeIf[ANNOTATION_COPY_BLACKLIST.contains(it.name)]
         	addTagAnnotation(SCGAnnotations.ANNOTATION_SEQUENTIALIZED)
         	label = scg.label
         	name = scg.name

--- a/plugins/de.cau.cs.kieler.verification/system/de.cau.cs.kieler.sccharts.netlist.smv.kico
+++ b/plugins/de.cau.cs.kieler.verification/system/de.cau.cs.kieler.sccharts.netlist.smv.kico
@@ -29,10 +29,10 @@ post process de.cau.cs.kieler.scg.processors.copyPropagation
 post process de.cau.cs.kieler.scg.processors.conditionalMerger
 post process de.cau.cs.kieler.scg.processors.haltStateRemover
 // Advanced optimizations on seq. SCG
-de.cau.cs.kieler.scg.processors.smartRegisterAllocation
-de.cau.cs.kieler.scg.processors.persistentStateOptimizer
-de.cau.cs.kieler.scg.processors.partialAssignmentEvaluation
-de.cau.cs.kieler.scg.processors.partialAssignmentEvaluation
+post process de.cau.cs.kieler.scg.processors.smartRegisterAllocation
+post process de.cau.cs.kieler.scg.processors.persistentStateOptimizer
+post process de.cau.cs.kieler.scg.processors.partialAssignmentEvaluation
+post process de.cau.cs.kieler.scg.processors.partialAssignmentEvaluation
 // Clean up valued objects
 post process silent de.cau.cs.kieler.scg.processors.cleanupValuedObjects
 post process de.cau.cs.kieler.kicool.deploy.variable.store.clean


### PR DESCRIPTION
This prevents the sequentialized SCG from carrying annotations that indicate a then invalid SCG state, e.g., guarded.

Closes #24