### PR TITLE
language.server: add -Djava.awt.headless=true parameter to launch config

### DIFF
--- a/plugins/de.cau.cs.kieler.language.server/run-configurations/LanguageServer with KLighD in Workspace.launch
+++ b/plugins/de.cau.cs.kieler.language.server/run-configurations/LanguageServer with KLighD in Workspace.launch
@@ -116,5 +116,5 @@
     <listAttribute key="org.eclipse.jdt.launching.MODULEPATH"/>
     <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="de.cau.cs.kieler.language.server"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="de.cau.cs.kieler.language.server"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dport=5007"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dport=5007 -Djava.awt.headless=true"/>
 </launchConfiguration>

--- a/plugins/de.cau.cs.kieler.language.server/run-configurations/LanguageServer.launch
+++ b/plugins/de.cau.cs.kieler.language.server/run-configurations/LanguageServer.launch
@@ -86,5 +86,5 @@
     <listAttribute key="org.eclipse.jdt.launching.MODULEPATH"/>
     <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="de.cau.cs.kieler.language.server"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="de.cau.cs.kieler.language.server"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dport=5007"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dport=5007 -Djava.awt.headless=true"/>
 </launchConfiguration>


### PR DESCRIPTION
The language server is a headless process and should therefore also run
in headless mode.
Fixes an issue where AWT would deadlock the LS on MacOS.