### PR TITLE
sccharts.ui: make the +/- text of the collapse/expand button a child of the polygon.

### DIFF
--- a/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/styles/ControlflowRegionStyles.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/styles/ControlflowRegionStyles.xtend
@@ -134,7 +134,7 @@ class ControlflowRegionStyles {
      * Adds a button with text.
      */
     private def KRendering addRegionButton(KContainerRendering container, String text, List<Pair<? extends CharSequence, TextFormat>> label) {
-        val button =container.addPolygon => [
+        val button = container.addPolygon => [
             lineWidth = 0
             background = container.foreground.color.copy
             selectionBackground = SELECTION.color
@@ -142,7 +142,7 @@ class ControlflowRegionStyles {
             addKPosition(LEFT, 0.5f, 0, TOP, 19, 0)
             addKPosition(LEFT, 18, 0, TOP, 0.5f, 0)
         ]
-        container.addText(text) => [
+        button.addText(text) => [
             suppressSelectability
             foreground = REGION_BUTTON_FOREGROUND.color
             selectionForeground = REGION_BUTTON_FOREGROUND.color


### PR DESCRIPTION
This makes action execution when clicking on the text directly
consistent between Piccolo (top-to-bottom action execution on the
canvas) and klighd-vscode's SVG implementation (child-to-parent
execution), causing the action on the polygon to be executed when
clicking the text in both cases.