### PR TITLE
Adapt LS to new versions

### DIFF
--- a/oomph/kieler-semantics-developers.setup
+++ b/oomph/kieler-semantics-developers.setup
@@ -2389,12 +2389,6 @@
         <requirement
             name="org.eclipse.jst.ws.jaxws.feature.feature.group"/>
         <requirement
-            name="javax.xml.bind"/>
-        <requirement
-            name="javax.xml.stream"/>
-        <requirement
-            name="javax.transaction"/>
-        <requirement
             name="com.google.inject"/>
         <requirement
             name="com.google.guava"
@@ -2405,17 +2399,15 @@
         <requirement
             name="edu.umd.cs.piccolo"/>
         <requirement
-            name="org.eclipse.xtext.runtime.feature.group"
-            versionRange="[2.25.0,2.26.0)"/>
+            name="org.eclipse.xtext.sdk.feature.group"
+            versionRange="[2.27.0,2.28.0)"/>
         <requirement
             name="org.eclipse.emf.mwe2.launcher.feature.group"/>
-        <requirement
-            name="org.eclipse.xpand.feature.group"/>
         <requirement
             name="org.eclipse.emf.compare.feature.group"/>
         <requirement
             name="org.eclipse.lsp4j.sdk.feature.group"
-            versionRange="[0.10.0,0.11.0)"/>
+            versionRange="[0.14.0,0.15.0)"/>
         <requirement
             name="org.eclipse.elk.sdk.feature.feature.group"/>
         <requirement
@@ -2451,21 +2443,21 @@
         <requirement
             name="de.cau.cs.kieler.websocket.mirror"/>
         <requirement
-            name="javax.servlet"/>
+            name="jakarta.servlet"/>
         <requirement
             name="org.eclipse.sprotty"/>
         <repositoryList
             name="FixedTarget">
           <repository
-              url="http://download.eclipse.org/releases/2021-06"/>
+              url="http://download.eclipse.org/releases/2022-06"/>
           <repository
-              url="http://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository/"/>
+              url="http://download.eclipse.org/tools/orbit/downloads/drops/R20220531185310/repository/"/>
           <repository
-              url="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.25.0/"/>
+              url="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.27.0/"/>
           <repository
-              url="http://download.eclipse.org/lsp4j/updates/releases/0.10.0"/>
+              url="http://download.eclipse.org/lsp4j/updates/releases/0.14.0"/>
           <repository
-              url="https://download.eclipse.org/elk/updates/releases/0.7.1/"/>
+              url="https://download.eclipse.org/elk/updates/releases/0.8.1/"/>
           <repository
               url="https://rtsys.informatik.uni-kiel.de/~kieler/updatesite/nightly/klighd/"/>
           <repository
@@ -2479,9 +2471,9 @@
         xsi:type="setup.p2:P2Task">
       <requirement
           name="org.eclipse.xtext.sdk.feature.group"
-          versionRange="[2.25.0,2.26.0)"/>
+          versionRange="[2.27.0,2.28.0)"/>
       <repository
-          url="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.25.0/"/>
+          url="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.27.0/"/>
     </setupTask>
   </stream>
   <logicalProjectContainer

--- a/plugins/de.cau.cs.kieler.kicool.ui/src/de/cau/cs/kieler/kicool/ui/klighd/KicoolKlighdSetup.xtend
+++ b/plugins/de.cau.cs.kieler.kicool.ui/src/de/cau/cs/kieler/kicool/ui/klighd/KicoolKlighdSetup.xtend
@@ -39,6 +39,7 @@ import de.cau.cs.kieler.kicool.ui.view.registry.FocusNodeAction
 import de.cau.cs.kieler.kicool.ui.view.registry.KiCoolRegistrySynthesis
 import de.cau.cs.kieler.kicool.ui.view.registry.KiCoolSystemsSynthesis
 import de.cau.cs.kieler.klighd.IKlighdStartupHook
+import de.cau.cs.kieler.klighd.Klighd
 import de.cau.cs.kieler.klighd.KlighdDataManager
 
 /**
@@ -53,7 +54,6 @@ class KicoolKlighdSetup implements IKlighdStartupHook {
             .registerAction(SelectIntermediateAction.ID, new SelectIntermediateAction)
             .registerAction(SelectAdditionalIntermediateAction.ID, new SelectAdditionalIntermediateAction)
             .registerAction(ToggleProcessorOnOffAction.ID, new ToggleProcessorOnOffAction)
-            .registerAction(OpenCodeInEditorAction.ID, new OpenCodeInEditorAction)
             .registerAction(RemoveChainElementAction.ID, new RemoveChainElementAction)
             .registerAction(SelectNothing.ID, new SelectNothing)
             .registerAction(SelectParent.ID, new SelectParent)
@@ -76,6 +76,12 @@ class KicoolKlighdSetup implements IKlighdStartupHook {
             .registerDiagramSynthesisClass("de.cau.cs.kieler.kicool.ui.synthesis.KASTSynthesis", KASTSynthesis)
             .registerDiagramSynthesisClass("de.cau.cs.kieler.kicool.ui.view.registry.KiCoolSystemsSynthesis", KiCoolSystemsSynthesis)
             .registerDiagramSynthesisClass("de.cau.cs.kieler.kicool.ui.JavaASTSynthesis", JavaASTSynthesis)
+        
+        // Only register UI stuff in Eclipse case.
+        if (Klighd.IS_PLATFORM_RUNNING) {
+            KlighdDataManager.instance
+                .registerAction(OpenCodeInEditorAction.ID, new OpenCodeInEditorAction)
+        }
     }
     
 }


### PR DESCRIPTION
Update the Oomph setup for the LS stream to new versions as on the master stream. Prevent an issue from calling eclipse.ui code in LS causing a security exception because of differently signed eclipse.ui package classes in development mode