### PR TITLE
sccharts.ui: comment nodes of edges now also lead back to their code.

### DIFF
--- a/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/TransitionSynthesis.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/TransitionSynthesis.xtend
@@ -173,8 +173,9 @@ class TransitionSynthesis extends SubSynthesis<Transition, KEdge> {
         };
         
         if (SHOW_COMMENTS.booleanValue) {
-            transition.getCommentAnnotations.forEach[
-                edge.addLabel(it.values.head, COMMENT_BACKGROUND_GRADIENT_2.color) => [
+            transition.getCommentAnnotations.forEach[ comment |
+                edge.addLabel(comment.values.head, COMMENT_BACKGROUND_GRADIENT_2.color) => [
+                    associateWith(comment)
                     configureLabelLOD(transition)
                 ]
             ]


### PR DESCRIPTION
Previously comment nodes on states led back to the code, those of edges did not. This makes the behavior consistent so both lead back to the code.