### PR TITLE
Range Assumptions Propagation

### DIFF
--- a/plugins/de.cau.cs.kieler.sccharts/src/de/cau/cs/kieler/sccharts/processors/CountDelay.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts/src/de/cau/cs/kieler/sccharts/processors/CountDelay.xtend
@@ -237,11 +237,13 @@ class CountDelay extends SCChartsProcessor implements Traceable {
     private def verificationHack(ValuedObject counter, int triggerDelay) {
         try {
             // Add range assumption for verification
-            if(compilationContext.class.simpleName.equals("VerificationContext")) {
-                compilationContext.class.getMethod("addRangeAssumtion", ValuedObject, int, int).invoke(compilationContext, counter, 0, triggerDelay)
-            }
+            compilationContext.startEnvironment.allProperties.forEach[p1, p2|
+                if(p1.id.equals("de.cau.cs.kieler.verification.context")) {
+                    p2.class.getMethod("addRangeAssumtion", ValuedObject, int, int).invoke(p2, counter, 0, triggerDelay)
+                }
+            ]
         } catch (Exception e) {
-            // Nobody cares
+            environment.errors.add(new Exception("Range assumption could not be copied for CountDelay"))
         }
     }
 

--- a/plugins/de.cau.cs.kieler.sccharts/src/de/cau/cs/kieler/sccharts/processors/Pre.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts/src/de/cau/cs/kieler/sccharts/processors/Pre.xtend
@@ -315,7 +315,6 @@ class Pre extends SCChartsProcessor implements Traceable {
      * This hacks some verification adaption into this transformation without introducing a dependency to kieler.verification
      */
     private def verificationHack(ValuedObject vo, ValuedObject source) {
-        
         try {
             // Copy range assumptions for verification
             compilationContext.startEnvironment.allProperties.forEach[p1, p2|

--- a/plugins/de.cau.cs.kieler.sccharts/src/de/cau/cs/kieler/sccharts/processors/Pre.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts/src/de/cau/cs/kieler/sccharts/processors/Pre.xtend
@@ -39,6 +39,8 @@ import org.eclipse.emf.ecore.EObject
 
 import static extension de.cau.cs.kieler.kicool.kitt.tracing.TransformationTracing.*
 import static extension org.eclipse.emf.ecore.util.EcoreUtil.*
+import de.cau.cs.kieler.core.properties.IProperty
+import de.cau.cs.kieler.kicool.environments.Environment
 
 /**
  * SCCharts Pre Transformation.
@@ -313,13 +315,16 @@ class Pre extends SCChartsProcessor implements Traceable {
      * This hacks some verification adaption into this transformation without introducing a dependency to kieler.verification
      */
     private def verificationHack(ValuedObject vo, ValuedObject source) {
+        
         try {
             // Copy range assumptions for verification
-            if(compilationContext.class.simpleName.equals("VerificationContext")) {
-                compilationContext.class.getMethod("copyAssumptions", ValuedObject, ValuedObject).invoke(compilationContext, vo, source)
-            }
+            compilationContext.startEnvironment.allProperties.forEach[p1, p2|
+                if(p1.id.equals("de.cau.cs.kieler.verification.context")) {
+                    p2.class.getMethod("copyAssumptions", ValuedObject, ValuedObject).invoke(p2, vo, source)
+                }
+            ]
         } catch (Exception e) {
-            // Nobody cares
+            environment.errors.add(new Exception("Pre expression range assumption could not be copied"))
         }
     }
     

--- a/plugins/de.cau.cs.kieler.sccharts/src/de/cau/cs/kieler/sccharts/processors/Pre.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts/src/de/cau/cs/kieler/sccharts/processors/Pre.xtend
@@ -39,8 +39,6 @@ import org.eclipse.emf.ecore.EObject
 
 import static extension de.cau.cs.kieler.kicool.kitt.tracing.TransformationTracing.*
 import static extension org.eclipse.emf.ecore.util.EcoreUtil.*
-import de.cau.cs.kieler.core.properties.IProperty
-import de.cau.cs.kieler.kicool.environments.Environment
 
 /**
  * SCCharts Pre Transformation.


### PR DESCRIPTION
Closes #87 

See Description in linked issue.

I tested this change with SCTX models with and without the "pre" operator, for all pipelines that I could run. Generated SMVs now have the correct range in the variables generated from the pre-operator.

This is a draft PR because I would first want to briefly discuss whether this sort of workaround is acceptable, and whether any related things would need changing here. Thus tagging @a-sr :)
