### PR TITLE
Rename Language Server Artifact to "kieler-language-server.jar"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           cp -r build/de.cau.cs.kieler.kicool.klighd.cli/target/exe/* products/cli
           cp -r build/de.cau.cs.kieler.sccharts.cli/target/exe/* products/cli
           mkdir products/ls
-          cp build/de.cau.cs.kieler.language.server.cli/target/de.cau.cs.kieler.language.server.cli-*-app.jar products/ls
+          cp build/de.cau.cs.kieler.language.server.cli/target/kieler-language-server.jar products/ls
       - name: Archive All Products
         if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') }}
         uses: actions/upload-artifact@v4
@@ -227,7 +227,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: KIELER Language Server
-          path: build/de.cau.cs.kieler.language.server.cli/target/de.cau.cs.kieler.language.server.cli-*-app.jar
+          path: build/de.cau.cs.kieler.language.server.cli/target/kieler-language-server.jar
           if-no-files-found: error
 
   testMac:

--- a/build/de.cau.cs.kieler.language.server.cli/pom.xml
+++ b/build/de.cau.cs.kieler.language.server.cli/pom.xml
@@ -94,6 +94,7 @@
               </filter>
           </filters>
           <shadedArtifactAttached>true</shadedArtifactAttached>
+          <finalName>kieler-language-server</finalName>
           <shadedClassifierName>app</shadedClassifierName>
           <minimizeJar>false</minimizeJar>
         </configuration>


### PR DESCRIPTION
The VS Code Extension always expects the language server to be named specifically `kieler-language-server.jar`, this way the shading plugin will always output the jar with the correct name already.