### PR TITLE
Aligned jetty dependencies with the kieler websocket mirror

### DIFF
--- a/language-server/de.cau.cs.kieler.language.server/pom.xml
+++ b/language-server/de.cau.cs.kieler.language.server/pom.xml
@@ -111,12 +111,43 @@
       <artifactId>javax.servlet-api</artifactId>
       <version>4.0.1</version>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-servlet -->
+
+    <!-- All Jetty Dependencies -->
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-      <version>11.0.11</version>
-    </dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>10.0.20</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>10.0.20</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <version>10.0.20</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-io</artifactId>
+            <version>10.0.20</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>10.0.20</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-jetty-server</artifactId>
+            <version>10.0.20</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-jetty-api</artifactId>
+            <version>10.0.20</version>
+        </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
This aligns the Maven dependencies of Jetty in the language server with the dependencies as listed in the [websocket mirror](https://github.com/kieler/jetty-websocket-mirror/blob/master/plugins/de.cau.cs.kieler.websocket.mirror/pom.xml), specifically including some missing dependencies to make the simulation visualization work again.