### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
       
       # Configure maven artifact caching
       - name: Cache local Maven repository


### PR DESCRIPTION
Adopt is deprecated and to be replaced by temurin, see https://github.com/actions/setup-java/?tab=readme-ov-file#supported-distributions