### PR TITLE
Fixed syntax error in SCEst code generation for signal bodies

### DIFF
--- a/plugins/de.cau.cs.kieler.esterel/src/de/cau/cs/kieler/esterel/processors/transformators/incremental/SignalTransformation.xtend
+++ b/plugins/de.cau.cs.kieler.esterel/src/de/cau/cs/kieler/esterel/processors/transformators/incremental/SignalTransformation.xtend
@@ -136,8 +136,10 @@ class  SignalTransformation extends AbstractSCEstDynamicProcessor<Module> {
             val parallel = createParallel
             val thread2 = createThread
             parallel.threads.add(thread2)
-            thread2.statements.addAll(module.statements)
-            thread2.statements.add(createAssignment(term, createTrue))
+            var scope = createScopeStatement
+            thread2.statements.add(scope)
+            scope.statements.addAll(module.statements)
+            scope.statements.add(createAssignment(term, createTrue))
             module.statements.add(parallel)
             module.declarations.add(decl)
             


### PR DESCRIPTION
#119 

Because input/output signals did not create a new scope, if the first statement of the body created a scope (like a local signal or variable), then the parser assumes that scope belongs to the top level which results in a syntax error.

This commit simply adds an explicit scope to the Signal transformation.