### PR TITLE
add fuzziness to edge labels

### DIFF
--- a/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/hooks/LabelShorteningHook.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/hooks/LabelShorteningHook.xtend
@@ -20,11 +20,11 @@ import de.cau.cs.kieler.klighd.kgraph.KNode
 import de.cau.cs.kieler.klighd.krendering.ViewSynthesisShared
 import de.cau.cs.kieler.sccharts.Scope
 import de.cau.cs.kieler.sccharts.Transition
-import de.cau.cs.kieler.sccharts.ui.synthesis.hooks.SynthesisActionHook
 import de.cau.cs.kieler.sccharts.ui.synthesis.GeneralSynthesisOptions
 import de.cau.cs.kieler.sccharts.ui.synthesis.labels.LabelFocusSelectionListener
 import de.cau.cs.kieler.sccharts.ui.synthesis.labels.LabelShorteningStrategies
 import org.eclipse.elk.core.labels.LabelManagementOptions
+import org.eclipse.elk.core.options.CoreOptions
 
 import static extension de.cau.cs.kieler.klighd.syntheses.DiagramSyntheses.*
 import static extension de.cau.cs.kieler.klighd.util.ModelingUtil.*
@@ -81,6 +81,9 @@ class LabelShorteningHook extends SynthesisActionHook {
         if (HIDE_LABELS.booleanValue) {
             edge.eContents.filter(KLabel).forEach[initiallyHide]
         }
+        edge.labels.forEach[
+            it.setProperty(CoreOptions::SOFTWRAPPING_FUZZINESS, 0.3)
+        ]
     }
 
     override executeAction(KNode rootNode) {


### PR DESCRIPTION
Sets the wrapping fuzziness to reasonable default value in the label shortening hook.

This could also be configurable via a synthesis option but it doesn't seem that helpful for regular users.

depends on:
- https://github.com/eclipse/elk/pull/1082
- https://github.com/kieler/KLighD/pull/218

requires KLighD 3.1.0