### PR TITLE
replace region surrounding spacing by ELK nodeNodeSpacing

### DIFF
--- a/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/StateSynthesis.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/StateSynthesis.xtend
@@ -375,7 +375,7 @@ class StateSynthesis extends SubSynthesis<State, KNode> {
                 || (SHOW_INHERITANCE.booleanValue && !state.allVisibleInheritedRegions.empty)
                 || !state.declarations.filter(MethodImplementationDeclaration).empty
             ) {
-                node.addRegionsArea
+                node.addRegionsArea(state)
                 node.setLayoutOption(CoreOptions.NODE_SIZE_CONSTRAINTS, EnumSet.of(SizeConstraint.MINIMUM_SIZE))
             }
         }

--- a/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/StateSynthesis.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/StateSynthesis.xtend
@@ -491,7 +491,7 @@ class StateSynthesis extends SubSynthesis<State, KNode> {
         node.setLayoutOption(RectPackingOptions.WHITE_SPACE_ELIMINATION_STRATEGY, WhiteSpaceEliminationStrategy.EQUAL_BETWEEN_STRUCTURES)
         node.setLayoutOption(RectPackingOptions.OMIT_NODE_MICRO_LAYOUT, true)
         node.setLayoutOption(CoreOptions::PADDING, new ElkPadding(0))
-        node.setLayoutOption(CoreOptions::SPACING_NODE_NODE, 1.0)
+        node.setLayoutOption(CoreOptions::SPACING_NODE_NODE, 5.0)
     }
     
     def static void configureLayoutRegionDependencies(KNode node) {

--- a/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/hooks/ActionsAsDataflowHook.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/hooks/ActionsAsDataflowHook.xtend
@@ -77,7 +77,7 @@ class ActionsAsDataflowHook extends SynthesisHook {
         
         if (SHOW_ACTIONS_AS_DATAFLOW.booleanValue) {
             container.children.remove(actionContainer)
-            node.addRegionsArea
+            node.addRegionsArea(state)
             
             val actions = <Action> newArrayList(state.actions)
             

--- a/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/styles/ControlflowRegionStyles.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/styles/ControlflowRegionStyles.xtend
@@ -76,7 +76,6 @@ class ControlflowRegionStyles {
             background = REGION_BACKGROUND.color;
             foreground = REGION_FOREGROUND.color;
             lineWidth = 1;
-//            setSurroundingSpace(2, 0);
         ]
     }
     

--- a/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/styles/ControlflowRegionStyles.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/styles/ControlflowRegionStyles.xtend
@@ -76,7 +76,7 @@ class ControlflowRegionStyles {
             background = REGION_BACKGROUND.color;
             foreground = REGION_FOREGROUND.color;
             lineWidth = 1;
-            setSurroundingSpace(2, 0);
+//            setSurroundingSpace(2, 0);
         ]
     }
     

--- a/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/styles/StateStyles.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/styles/StateStyles.xtend
@@ -377,9 +377,10 @@ class StateStyles {
     /**
      * Add a child area to a macro state
      */
-    def addRegionsArea(KNode node) {
+    def addRegionsArea(KNode node, State state) {
         node.contentContainer.addChildArea().setGridPlacementData() => [
-            from(LEFT, 5, 0, TOP, -4, 0).to(RIGHT, 5, 0, BOTTOM, 5, 0)
+            val spacing = state.isInitial ? 9 : 7;
+            from(LEFT, spacing, 0, TOP, -4, 0).to(RIGHT, spacing, 0, BOTTOM, spacing, 0)
             minCellHeight = 5;
             minCellWidth = 5;
         ]


### PR DESCRIPTION
This makes is possible to control the spacing directly through layout options, which is convenient, but the spacing on the outside of the layout i.e. the spacing between the border of the state and the regions is slightly different than before.

Before:
![image](https://github.com/user-attachments/assets/001511c7-1303-4b12-97a3-32f7148609ba)

After:
![image](https://github.com/user-attachments/assets/f4da75d6-b7cc-45d3-b7dc-d2229d04ce61)
