### PR TITLE
Remove rendering if priority label is empty.

### DIFF
--- a/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/labels/TransitionPriorityLabelManager.java
+++ b/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/labels/TransitionPriorityLabelManager.java
@@ -68,6 +68,7 @@ public class TransitionPriorityLabelManager extends AbstractKlighdLabelManager {
                         return Result.modified(matcher.group(1) + ".");
                     } else {
                         // If no priority available 
+                        label.setProperty(KRenderingOptions.K_RENDERING, null);
                         return Result.modified("");
                     }
                 }


### PR DESCRIPTION
If no priority is available delete the rendering. This fixes the issue of the empty rendering being displayed for on edge labels.

See https://github.com/kieler/KLighD/pull/231