### PR TITLE
SCEst: Allow host types in SLIC compilation

### DIFF
--- a/plugins/de.cau.cs.kieler.esterel/src/de/cau/cs/kieler/esterel/processors/transformators/incremental/EmitTransformation.xtend
+++ b/plugins/de.cau.cs.kieler.esterel/src/de/cau/cs/kieler/esterel/processors/transformators/incremental/EmitTransformation.xtend
@@ -47,7 +47,8 @@ class EmitTransformation extends AbstractSCEstDynamicProcessor<Emit> {
         
     override transform(Emit emit) {
         var signal = emit.signal as Signal
-        if (emit.expression === null && signal.type != ValueType.PURE) {
+        val isValued = signal.type != ValueType.PURE || signal.idType !== null
+        if (emit.expression === null && isValued) {
             throw new UnsupportedOperationException("The following signal is a valued signal. 
                                     Thus a non valued emit is invalid! " + signal.toString)
         }
@@ -57,7 +58,7 @@ class EmitTransformation extends AbstractSCEstDynamicProcessor<Emit> {
         val assign = createAssignment(signal.createSignalReference, expr)
         emit.replace(assign)
         if (emit.expression !== null) {
-            if (signal.type != ValueType.PURE) {
+            if (isValued) {
                 var Assignment assign2
                 // if no combineOperator exists, handle valued signal like Karsten Rathlev did in his master thesis
                 if (signal.combineOperator === null || signal.combineOperator == CombineOperator.NONE) {

--- a/plugins/de.cau.cs.kieler.esterel/src/de/cau/cs/kieler/esterel/processors/transformators/incremental/LocalSignalDeclTransformation.xtend
+++ b/plugins/de.cau.cs.kieler.esterel/src/de/cau/cs/kieler/esterel/processors/transformators/incremental/LocalSignalDeclTransformation.xtend
@@ -58,9 +58,10 @@ class LocalSignalDeclTransformation extends AbstractSCEstDynamicProcessor<LocalS
             var decl = createDeclaration(ValueType.BOOL, s)
             voStore.update(s, "signal")
             var decl2 = createDeclaration(null, null)
-            if (signal.type !== null) {
+            val isValued = signal.type != ValueType.PURE || signal.idType !== null
+            if (signal.type !== null || signal.idType !== null) {
                 scope.declarations.add(decl)
-                if (signal.type == ValueType.PURE) {
+                if (!isValued) {
                     signalsMap.put(signal, new NewSignals(s))
                 }
                 else {
@@ -68,8 +69,11 @@ class LocalSignalDeclTransformation extends AbstractSCEstDynamicProcessor<LocalS
                     decl.valuedObjects.add(s_set)
                     val s_val = createSignalVariable(signal.initialValue, signal.combineOperator, s.name + "_val")
                     val s_cur = createSignalVariable(null, signal.combineOperator, s.name + "_cur")
-                    val tempType = if (signal.type == ValueType.DOUBLE) ValueType.FLOAT else signal.type
+                    val tempType = if (signal.idType !== null) ValueType.HOST
+                        else if (signal.type == ValueType.DOUBLE) ValueType.FLOAT
+                        else signal.type
                     decl2 = createDeclaration(tempType, null)
+                    if (signal.idType !== null) decl2.hostType = signal.idType
                     decl2.valuedObjects.add(s_val)
                     decl2.valuedObjects.add(s_cur)
                     signalsMap.put(signal, new NewSignals(s, s_set, s_cur, s_val))

--- a/plugins/de.cau.cs.kieler.esterel/src/de/cau/cs/kieler/esterel/processors/transformators/incremental/SCLTransformation.xtend
+++ b/plugins/de.cau.cs.kieler.esterel/src/de/cau/cs/kieler/esterel/processors/transformators/incremental/SCLTransformation.xtend
@@ -19,6 +19,7 @@ import de.cau.cs.kieler.scl.Module
 import de.cau.cs.kieler.scl.SCLProgram
 import de.cau.cs.kieler.kicool.compilation.Processor
 import de.cau.cs.kieler.kicool.compilation.ProcessorType
+import org.eclipse.emf.ecore.util.EcoreUtil
 
 /**
  * @author mrb
@@ -71,6 +72,9 @@ class SCLTransformation extends Processor<EsterelProgram, SCLProgram> {
     
     def transform(EsterelProgram prog) {
         val sclProg = createSCLProg
+        for (p : prog.pragmas) {
+            sclProg.pragmas += EcoreUtil.copy(p)
+        }
         for (m : prog.modules.filter(Module)) {
             val module = createSCLModule
             sclProg.modules += module

--- a/plugins/de.cau.cs.kieler.esterel/src/de/cau/cs/kieler/esterel/processors/transformators/incremental/SignalTransformation.xtend
+++ b/plugins/de.cau.cs.kieler.esterel/src/de/cau/cs/kieler/esterel/processors/transformators/incremental/SignalTransformation.xtend
@@ -69,9 +69,9 @@ class  SignalTransformation extends AbstractSCEstDynamicProcessor<Module> {
                 val decl = createDeclaration(ValueType.BOOL, s)
                 voStore.update(s, "signal")
                 var decl2 = createDeclaration(null, null)
-                if (signal.type !== null) {
+                if (signal.type !== null || signal.idType !== null) {
                     module.declarations.add(decl)
-                    if (signal.type == ValueType.PURE) {
+                    if (signal.type == ValueType.PURE && signal.idType === null) {
                         newSignals.put(signal, new NewSignals(s))
                     }
                     else {
@@ -79,8 +79,17 @@ class  SignalTransformation extends AbstractSCEstDynamicProcessor<Module> {
                         decl.valuedObjects.add(s_set)
                         val s_cur = createSignalVariable(null, signal.combineOperator, s.name + "_cur")
                         val s_val = createSignalVariable(signal.initialValue, signal.combineOperator, s.name + "_val")
-                        val tempType = if (signal.type == ValueType.DOUBLE) ValueType.FLOAT else signal.type
+                        val tempType = if (signal.idType !== null) {
+                            ValueType.HOST
+                        } else if (signal.type == ValueType.DOUBLE) {
+                            ValueType.FLOAT
+                        } else {
+                            signal.type
+                        }
                         decl2 = createDeclaration(tempType, null)
+                        if (signal.idType !== null) {
+                            decl2.hostType = signal.idType
+                        }
                         decl2.valuedObjects.add(s_cur)
                         decl2.valuedObjects.add(s_val)
                         newSignals.put(signal, new NewSignals(s, s_set, s_cur, s_val))
@@ -112,13 +121,6 @@ class  SignalTransformation extends AbstractSCEstDynamicProcessor<Module> {
         ]
         model.checkGotos
     }
-    
-    /*
-     *  TODO only the signals with type != null will be transformed
-     *  signals with typeID != null are not handled
-     *  SCL doesn't allow anything else then the predefined types
-     *  see KExt.xtext => Declaration
-    */
     
     def createParallelForSignals(Module module, HashMap<Signal, NewSignals> signalsMap) {
         var necessary = false

--- a/plugins/de.cau.cs.kieler.scg/src/de/cau/cs/kieler/scg/processors/codegen/c/CCodeGeneratorLogicModule.xtend
+++ b/plugins/de.cau.cs.kieler.scg/src/de/cau/cs/kieler/scg/processors/codegen/c/CCodeGeneratorLogicModule.xtend
@@ -431,10 +431,11 @@ class CCodeGeneratorLogicModule extends SCGCodeGeneratorModule {
         reset.code.append(indentation).append(struct.getVariableName).append(struct.separator).append(name).append(" = 0;\n")
         
         // Add the "register save" in the tick function.
-        prePrefix = "_"
+        valuedObjectPrefix = struct.getVariableName + struct.separator
+        prePrefix = ""
         tick.code.append(indentation)
         tick.code.append(struct.getVariableName).append(struct.separator).append(name).append(" = ")
-        tick.code.append(struct.getVariableName).append(struct.separator).append(operatorExpression.serializeHR).append(";\n")
+        tick.code.append(operatorExpression.subExpressions.head.serializeHR).append(";\n")
     }
     
     protected def List<Assignment> splitAssignment(Assignment assignment) {

--- a/plugins/de.cau.cs.kieler.scl/src/de/cau/cs/kieler/scl/processors/transformators/SCLToSCGTransformation.xtend
+++ b/plugins/de.cau.cs.kieler.scl/src/de/cau/cs/kieler/scl/processors/transformators/SCLToSCGTransformation.xtend
@@ -16,6 +16,7 @@ package de.cau.cs.kieler.scl.processors.transformators
 import com.google.inject.Inject
 import de.cau.cs.kieler.annotations.StringAnnotation
 import de.cau.cs.kieler.annotations.extensions.AnnotationsExtensions
+import de.cau.cs.kieler.annotations.extensions.PragmaExtensions
 import de.cau.cs.kieler.kexpressions.Declaration
 import de.cau.cs.kieler.kexpressions.Expression
 import de.cau.cs.kieler.kexpressions.MethodDeclaration
@@ -78,6 +79,7 @@ import static de.cau.cs.kieler.scg.processors.SCGAnnotations.*
 import static extension de.cau.cs.kieler.kicool.kitt.tracing.TracingEcoreUtil.*
 import static extension de.cau.cs.kieler.kicool.kitt.tracing.TransformationTracing.*
 
+
 /** 
  * SCL to SCG Transformation 
  * 
@@ -97,6 +99,7 @@ class SCLToSCGTransformation extends Processor<SCLProgram, SCGraphs> implements 
     @Inject extension AnnotationsExtensions
     @Inject extension SCLExtensions
     @Inject extension KEffectsExtensions
+    @Inject extension PragmaExtensions
     static val sCGFactory = ScgFactory.eINSTANCE
     extension ScgFactory = ScgFactory::eINSTANCE
     static val sclFactory = SCLFactory::eINSTANCE
@@ -149,6 +152,7 @@ class SCLToSCGTransformation extends Processor<SCLProgram, SCGraphs> implements 
         // Create new SCG...
         val scgs = createSCGraphs
         creationalTransformation(program, scgs)
+        program.copyPragmas(scgs)
 
         for (module : program.modules) {
             val scg = createSCGraph


### PR DESCRIPTION
**Pre() syntax bugfix:**

Calling pre() on an IO signal would translate the pre-variable assignment in tick() as: `d->_pA = d->_A;`, when it should be `d->_pA = d->A;`

**Allow Host types:**

Previously, host types would not be compiled correctly. There was a TODO message saying "SCL doesn't allow anything else then the predefined types", which I think is no longer the case. I would like to use host types, hence, I have done some minimal edits which I hope are correct.

Example working snippet:

```
#hostcode "#include <mytypes.h>"

module minimal:
type NewType;
function get_some_obj() : NewType;
input A;
output B : NewType;

  present pre(A) then emit B(get_some_obj()) end;
  pause;

end module
```

Unlike in classic Esterel, I do not think the forward type declaration is actually used here (which is reasonable), but it is syntactically valid.