### PR TITLE
New connector semantics

### DIFF
--- a/plugins/de.cau.cs.kieler.core/src/de/cau/cs/kieler/core/definitions/Semantics.java
+++ b/plugins/de.cau.cs.kieler.core/src/de/cau/cs/kieler/core/definitions/Semantics.java
@@ -1,0 +1,22 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright ${year} by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This code is provided under the terms of the Eclipse Public License (EPL).
+ */
+package de.cau.cs.kieler.core.definitions;
+
+/**
+ * 
+ */
+public class Semantics {
+    public static String PRAGMA_LEGACY_SEMANTICS = "LegacySemantics";
+
+
+}

--- a/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/StateSynthesis.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/StateSynthesis.xtend
@@ -170,9 +170,15 @@ class StateSynthesis extends SubSynthesis<State, KNode> {
 
         //pre-evaluate type
         val isConnector = state.isConnector
+        val isInitialConnector = isConnector && state.isInitial;
 
         // Basic state style
         switch state {
+            case isInitialConnector: {
+                node.addInitialConnectorFigure
+                node.getProperty(KlighdProperties.SEMANTIC_FILTER_TAGS).add(SCChartsSemanticFilterTags.CONNECTOR_STATE)
+                proxy.addInitialConnectorFigure
+            }
             case isConnector: {
                 node.addConnectorFigure
                 node.getProperty(KlighdProperties.SEMANTIC_FILTER_TAGS).add(SCChartsSemanticFilterTags.CONNECTOR_STATE)

--- a/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/TransitionSynthesis.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/TransitionSynthesis.xtend
@@ -39,6 +39,8 @@ import static de.cau.cs.kieler.sccharts.ui.synthesis.GeneralSynthesisOptions.*
 import static de.cau.cs.kieler.sccharts.ui.synthesis.styles.ColorStore.Color.*
 
 import static extension de.cau.cs.kieler.klighd.syntheses.DiagramSyntheses.*
+import de.cau.cs.kieler.sccharts.extensions.SCChartsCoreExtensions
+import de.cau.cs.kieler.annotations.extensions.PragmaExtensions
 
 /**
  * Transforms {@link Transition} into {@link KEdge} diagram elements.
@@ -67,8 +69,11 @@ class TransitionSynthesis extends SubSynthesis<Transition, KEdge> {
     @Inject extension TransitionStyles
     @Inject extension ColorStore
     @Inject extension AdaptiveZoom
+    @Inject extension SCChartsCoreExtensions
+    @Inject extension PragmaExtensions
 
     override performTranformation(Transition transition) {
+        val legacySemantics = transition.getSCCharts.hasPragma("LegacySemantics");
         val edge = transition.createEdge().associateWith(transition);
         edge.configureEdgeLOD(transition)
 
@@ -89,7 +94,7 @@ class TransitionSynthesis extends SubSynthesis<Transition, KEdge> {
         edge.addTransitionSpline();
 
         // Modifiers
-        if (transition.isImplicitlyImmediate) {
+        if (transition.isImplicitlyImmediate && (legacySemantics || !transition.sourceState.isConnector)) {
             edge.setImmediateStyle
         }
         if (transition.nondeterministic) {

--- a/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/styles/StateStyles.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts.ui/src/de/cau/cs/kieler/sccharts/ui/synthesis/styles/StateStyles.xtend
@@ -111,6 +111,17 @@ class StateStyles {
     }
 
     /**
+     * Adds an initial connector figure.
+     */
+    def KRoundedRectangle addInitialConnectorFigure(KNode node) {
+        node.setMinimalNodeSize(0.5f * DEFAULT_FIGURE_MIN_NODE_SIZE, 0.5f * DEFAULT_FIGURE_MIN_NODE_SIZE);
+        node.addRoundedRectangle(DEFAULT_FIGURE_CORNER_RADIUS, DEFAULT_FIGURE_CORNER_RADIUS, baseLineWidth) => [
+            background = STATE_CONNECTOR.color;
+            foreground = STATE_CONNECTOR.color;
+        ]
+    }
+
+    /**
      * Adds a small state figure.
      */
     def KRoundedRectangle addDefaultFigure(KNode node) {

--- a/plugins/de.cau.cs.kieler.sccharts/src/de/cau/cs/kieler/sccharts/text/validation/SCTXValidator.xtend
+++ b/plugins/de.cau.cs.kieler.sccharts/src/de/cau/cs/kieler/sccharts/text/validation/SCTXValidator.xtend
@@ -76,6 +76,7 @@ import org.eclipse.xtext.validation.Check
 import org.eclipse.xtext.validation.CheckType
 
 import static extension java.lang.String.*
+import de.cau.cs.kieler.core.definitions.Semantics
 
 /**
  * This class contains custom validation rules. 
@@ -134,6 +135,7 @@ class SCTXValidator extends AbstractSCTXValidator {
     static val String CANNOT_BIND_LITERAL_TO_OUTPUT = "You cannot bind a literal to an output object."
     static val String DUPLICATE_VARIABLE = "The variable is declared multiple times in this scope."
     static val String NON_IMMEDIATE_CONNECTOR = "Outgoing transitions of connector states should be marked as immediate."
+    static val String IMMEDIATE_CONNECTOR = "Outgoing transitions of connector states should not be marked as immediate unless legacy semantics are used."
     static val String NO_DEFAULT_TRANSITION = "Connector states should have an outgoing transition without trigger."
     static val String NO_OUTGOING_TRANSITION = "Connector states must have an outgoing transition."
     static val String NON_REACHABLE_TRANSITION = "The transition is not reachable."
@@ -724,9 +726,12 @@ class SCTXValidator extends AbstractSCTXValidator {
         if(state.connector) {
             var Transition lastTransition
             var boolean transitionWithoutTrigger = false
+            val hasLegacySemantics = state.SCCharts.hasPragma(Semantics.PRAGMA_LEGACY_SEMANTICS)
             for(trans : state.outgoingTransitions) {
-                if(!trans.isImmediate) {
+                if(hasLegacySemantics && !trans.isImmediate) {
                     warning(NON_IMMEDIATE_CONNECTOR, trans, null)
+                } else if (!hasLegacySemantics && trans.isImmediate) {
+                    warning(IMMEDIATE_CONNECTOR, trans, null)
                 }
                 if(trans.trigger === null) {
                     transitionWithoutTrigger = true


### PR DESCRIPTION
- Initial connector states get special styling
- Transitions out of connectors should no longer be explicitly marked as immediate
- Transitions out of connectors are no longer styled as immediate